### PR TITLE
Use registered state from callback

### DIFF
--- a/app/src/main/java/com/rdapps/gamepad/service/BluetoothControllerService.java
+++ b/app/src/main/java/com/rdapps/gamepad/service/BluetoothControllerService.java
@@ -399,7 +399,7 @@ public class BluetoothControllerService extends Service implements BluetoothProf
                 QOS_DELAY_VARIATION
         );
 
-        boolean registeredApp = mBluetoothHidDevice.registerApp(
+        mBluetoothHidDevice.registerApp(
                 bluetoothHidDeviceAppSdpSettings,
                 qos,
                 qos,
@@ -407,7 +407,7 @@ public class BluetoothControllerService extends Service implements BluetoothProf
                 new Callback()
         );
 
-        if (!registeredApp) {
+        if (!appRegistered) {
             unregisterApp();
             mainHandler.post(() -> couldNotRegisterApp(getApplicationContext()));
         }


### PR DESCRIPTION
This will bypass a bug in Android 13 which got fixed but never made it into 13: https://android-review.googlesource.com/c/platform/packages/modules/Bluetooth/+/2072648